### PR TITLE
problem on intalling and on reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# homebridge-airthings-waveplus
-With this [Homebridge](https://github.com/nfarina/homebridge) plugin you can use [Airthings Wave Plus](https://www.airthings.com/wave-plus) with [Apple HomeKit](https://www.apple.com/ios/home/).
+# homebridge-airthings-wave-plus
+With this [Homebridge](https://github.com/nfarina/homebridge) plugin you can use [Airthings WavePlus](https://www.airthings.com/wave-plus) with [Apple HomeKit](https://www.apple.com/ios/home/).
 
-Kudos for inspiration and example to [pakastin](https://github.com/pakastin/homebridge-ruuvitag)!
+This code is heavily based on the work of iler's [homebridge-airthings-waveplus](https://github.com/iler/homebridge-airthings-waveplus) accessory, and the work of [pakastin](https://github.com/pakastin/homebridge-ruuvitag)!

--- a/README.md
+++ b/README.md
@@ -2,3 +2,34 @@
 With this [Homebridge](https://github.com/nfarina/homebridge) plugin you can use [Airthings WavePlus](https://www.airthings.com/wave-plus) with [Apple HomeKit](https://www.apple.com/ios/home/).
 
 This code is heavily based on the work of iler's [homebridge-airthings-waveplus](https://github.com/iler/homebridge-airthings-waveplus) accessory, and the work of [pakastin](https://github.com/pakastin/homebridge-ruuvitag)!
+
+This code is a work in progress.  There is currently a known issue around a bluetooth Stack Overflow in @abandonware/noble.
+
+# Configuration
+
+Example accessory config (needs to be added to the homebridge config.json):
+ ...
+
+		"accessories": [
+      {
+				"name": "Living Room WavePlus",
+				"serialNumber": "1234567890",
+				"disableTemp": false,
+				"disableHumidity": false,
+				"frequency": 60,
+				"accessory": "Airthings WavePlus"
+			}
+    ]
+ ...
+
+### Config Explanation:
+
+Field           			| Description
+----------------------------|------------
+**accessory**   			| (required) Must always be "Airthings WavePlus".
+**name**							| (required) The name you want to use for for the WavePlus in HomeKit.
+**serialNumber**			| (required) This shows up in the homekit accessory Characteristics and is used to index the control.
+**disableTemp**  			| (optional) Display a Temperature widget? Boolean value defaults to False if not present.
+**disableHumidity**		| (optional) Display a Humidity widget? Boolean value defaults to False if not present
+**frequency**					| (optional) Frequency in seconds to update readings in HomeKit.
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ With this [Homebridge](https://github.com/nfarina/homebridge) plugin you can use
 
 This code is heavily based on the work of iler's [homebridge-airthings-waveplus](https://github.com/iler/homebridge-airthings-waveplus) accessory, and the work of [pakastin](https://github.com/pakastin/homebridge-ruuvitag)!
 
-This code is a work in progress.  There is currently a known issue around a bluetooth Stack Overflow in @abandonware/noble.
+This code is a work in progress.  There is currently a known issue around a bluetooth buffer overflow error in @abandonware/noble:
+"processLeAdvertisingReport: Caught illegal packet (buffer overflow): RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 and <= 4. Received 6"
 
 # Configuration
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -9,7 +9,7 @@
       "description": "The WavePlus device name to show in HomeKit.",
 			"default": "My WavePlus"
 		},
-		"serial": {
+		"serialNumber": {
 			"title": "Serial Number",
 			"type": "string",
 			"required": true,

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,42 @@
+{
+	"pluginAlias": "Airthings WavePlus",
+	"pluginType": "accessory",
+	"schema": {
+		"name": {
+			"title": "Name",
+			"type": "string",
+			"required": true,
+      "description": "The WavePlus device name to show in HomeKit.",
+			"default": "My WavePlus"
+		},
+		"serial": {
+			"title": "Serial Number",
+			"type": "string",
+			"required": true,
+      "description": "The WavePlus serial number from the device's sticker.",
+			"default": "1234567890"
+		},
+		"disableTemp": {
+			"title": "disableTemp",
+			"type": "boolean",
+			"required": false,
+      "description": "If false, will display the WavePlus temperature reading in HomeKit.",
+			"default": "false"
+		},
+		"disableHumidity": {
+			"title": "disableHumidity",
+			"type": "boolean",
+			"required": false,
+      "description": "If false, will display the WavePlus humidity reading in HomeKit.",
+			"default": "false"
+		},
+		"frequency": {
+			"title": "frequency",
+			"type": "integer",
+			"required": false,
+      "description": "If set, provides the frequency (in seconds) for updating HomeKit.",
+			"default": 60
+		}
+	}
+}
+

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const devices = {};
 module.exports = (homebridge) => {
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
-  homebridge.registerAccessory('airthings-wave-plus', 'Airthings WavePlus', AirthingsWaveplus, true);
+  homebridge.registerAccessory('homebridge-wave-plus', 'Airthings WavePlus', AirthingsWaveplus, true);
 };
 
 class AirthingsWaveplus {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const devices = {};
 module.exports = (homebridge) => {
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
-  homebridge.registerAccessory('airthings-waveplus', 'Aithings Waveplus', AirthingsWaveplus, true);
+  homebridge.registerAccessory('airthings-wave-plus', 'Airthings WavePlus', AirthingsWaveplus, true);
 };
 
 class AirthingsWaveplus {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,11 @@
 {
+  "displayName": "Airthings WavePlus",
   "name": "homebridge-airthings-waveplus",
-  "version": "0.1.0",
-  "description": "Airthings Wave Plus bridge for Homebridge",
+  "version": "0.1.0"
+  "description": "A Homebridge plugin for Airthings WavePlus.",
+  "author": "ecoen66",
+  "license": "ISC",
   "main": "index.js",
-  "scripts": {
-    "test": ""
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/iler/homebridge-airthings-waveplus.git"
-  },
   "keywords": [
     "homebridge-plugin",
     "airthings",
@@ -23,10 +19,22 @@
     "node.js",
     "bluetooth"
   ],
-  "author": "Ilari Mäkelä",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/iler/homebridge-airthings-waveplus/issues"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ecoen66/homebridge-airthings-wave-plus.git"
   },
-  "homepage": "https://github.com/iler/homebridge-airthings-waveplus#readme"
+  "bugs": {
+    "url": "https://github.com/ecoen66/homebridge-airthings-wave-plus/issues"
+  },
+  "scripts": {
+    "test": ""
+  },
+	"dependencies": {
+		"node-airthings-waveplus": ">=0.2.0"
+	},
+	"devDependencies": {},
+	"engines": {
+		"homebridge": ">=0.2.0",
+		"node": ">=0.12.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
+  "private": false,
   "displayName": "Airthings WavePlus",
   "name": "homebridge-airthings-waveplus",
-  "version": "0.1.0"
+  "version": "0.1.1",
   "description": "A Homebridge plugin for Airthings WavePlus.",
   "author": "ecoen66",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "displayName": "Airthings WavePlus",
-  "name": "homebridge-airthings-wave-plus",
+  "name": "homebridge-wave-plus",
   "version": "0.1.1",
   "description": "A Homebridge plugin for Airthings WavePlus.",
   "author": "ecoen66",
@@ -22,10 +22,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ecoen66/homebridge-airthings-wave-plus.git"
+    "url": "git+https://github.com/ecoen66/homebridge-wave-plus.git"
   },
   "bugs": {
-    "url": "https://github.com/ecoen66/homebridge-airthings-wave-plus/issues"
+    "url": "https://github.com/ecoen66/homebridge-wave-plus/issues"
   },
   "scripts": {
     "test": ""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "displayName": "Airthings WavePlus",
-  "name": "homebridge-airthings-waveplus",
+  "name": "homebridge-airthings-wave-plus",
   "version": "0.1.1",
   "description": "A Homebridge plugin for Airthings WavePlus.",
   "author": "ecoen66",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Airthings WavePlus",
   "name": "homebridge-wave-plus",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A Homebridge plugin for Airthings WavePlus.",
   "author": "ecoen66",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Airthings WavePlus",
   "name": "homebridge-wave-plus",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A Homebridge plugin for Airthings WavePlus.",
   "author": "ecoen66",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Airthings WavePlus",
   "name": "homebridge-wave-plus",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A Homebridge plugin for Airthings WavePlus.",
   "author": "ecoen66",
   "license": "ISC",


### PR DESCRIPTION
homebridge@homebridge:/var/lib/homebridge$ sudo -E -n npm install -g homebridge-wave-plus@0.1.4

> usb@1.6.3 install /usr/lib/node_modules/homebridge-wave-plus/node_modules/usb
> prebuild-install --verbose || node-gyp rebuild

prebuild-install info begin Prebuild-install version 5.3.6
prebuild-install WARN install EACCES: permission denied, access '/home/homebridge/.npm'
gyp WARN EACCES current user ("nobody") does not have permission to access the dev dir "/home/homebridge/.cache/node-gyp/14.15.1"
gyp WARN EACCES attempting to reinstall using temporary dev dir "/usr/lib/node_modules/homebridge-wave-plus/node_modules/usb/.node-gyp"
gyp WARN install got an error, rolling back install
gyp WARN install got an error, rolling back install
gyp ERR! configure error 
gyp ERR! stack Error: EACCES: permission denied, mkdir '/usr/lib/node_modules/homebridge-wave-plus/node_modules/usb/.node-gyp'
gyp ERR! System Linux 5.4.0-53-generic
gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /usr/lib/node_modules/homebridge-wave-plus/node_modules/usb
gyp ERR! node -v v14.15.1
gyp ERR! node-gyp -v v5.1.0
gyp ERR! not ok 
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: usb@1.6.3 (node_modules/homebridge-wave-plus/node_modules/usb):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: usb@1.6.3 install: `prebuild-install --verbose || node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1

+ homebridge-wave-plus@0.1.4
updated 1 package in 25.607s




[27/11/2020, 23:08:05] ERROR LOADING PLUGIN homebridge-wave-plus:
[27/11/2020, 23:08:05] Error: ENODEV, No such device
    at Hci.init (/usr/lib/node_modules/homebridge-wave-plus/node_modules/@abandonware/noble/lib/hci-socket/hci.js:100:35)
    at NobleBindings.init (/usr/lib/node_modules/homebridge-wave-plus/node_modules/@abandonware/noble/lib/hci-socket/bindings.js:78:13)
    at Noble.get (/usr/lib/node_modules/homebridge-wave-plus/node_modules/@abandonware/noble/lib/noble.js:72:26)
    at new Adapter (/usr/lib/node_modules/homebridge-wave-plus/node_modules/node-airthings-waveplus/adapter.js:17:15)
    at Object.<anonymous> (/usr/lib/node_modules/homebridge-wave-plus/node_modules/node-airthings-waveplus/adapter.js:48:18)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)